### PR TITLE
Variable Naming Clarity and Consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ var listEvents = function(cb) {
     fetchEventsForSharedCalendars,
     fetchEventsForUserCalendars
   ];
-  parallel(tasks, function(err, results) {
-    if (err) {
-      log.error(err);
-      return cb(err);
+  parallel(tasks, function(error, results) {
+    if (error) {
+      log.error(error);
+      return cb(error);
     }
 
     var events = flatten(results);


### PR DESCRIPTION
You say variable names should be clear but in your example, your variable `err` and `results` doesn't follow the first rule "Code Consistency".

If should be `function(err, res)` or `function(error, results)` (the latter follows consistency AND clarity).